### PR TITLE
grapple rotation correction on return to player

### DIFF
--- a/js/actors/grapple.js
+++ b/js/actors/grapple.js
@@ -18,6 +18,7 @@ class Grapple extends Actor {
         this.extendSpeedFactor = 0.09;
         this.returnAcceleration = 1.15;
         this.returningSpeed = 5;
+        this.returningRotationSpeed = 0.15;
         this.calculateEndpoint(targetX, targetY);
         this.rotation = this.calculateRotation();
         this.calculateWirePositionOffsets();
@@ -89,6 +90,9 @@ class Grapple extends Actor {
         // TODO: change rotation on the way back
         const diffX = this.player.arm.getHandPositionX() - this.getWirePositionX();
         const diffY = this.player.arm.getHandPositionY() - this.getWirePositionY();
+        const goalRotation = MathUtil.calculateTheta(diffY, diffX);
+        this.rotation += MathUtil.minimumRotationDifference(this.rotation, goalRotation) * this.returningRotationSpeed;
+        this.calculateWirePositionOffsets();
         const mag = Math.sqrt(Math.pow(diffX, 2) + Math.pow(diffY, 2));
         this.returningSpeed *= this.returnAcceleration;
         if (this.returningSpeed < mag) {

--- a/js/camera.js
+++ b/js/camera.js
@@ -12,13 +12,11 @@ class Camera {
         this.zoomOffsetX = 0;
     }
 
-
     updatePosition() {
         const xDistance = this.anchor.getCenterX() - this.x;
         const yDistance = this.anchor.getCenterY() - this.y;
         this.moveTowardsAnchorLinearly(xDistance, yDistance);
     }
-
     
     moveTowardsAnchorLinearly(xDistance, yDistance) {
         this.x += Math.round(this.linearFollowStrength * xDistance);
@@ -56,5 +54,4 @@ class Camera {
     translateInputY(y) {
         return (this.y + (y- (canvas.height / 2)) / this.zoom);
     }
-
 }

--- a/js/math_util.js
+++ b/js/math_util.js
@@ -19,4 +19,19 @@ class MathUtil {
         return array[Math.floor(Math.random()*array.length)];
     }
 
+    /** 
+     * Needed because JS represents rotation in radians in a range of -PI to PI.
+     * In other words, JS doesn't know that a rotation of -PI is the same as a 
+     * rotation of PI. So we have to handle this ourselves.
+     */ 
+    static minimumRotationDifference(startRadians, goalRadians) {
+        console.log(goalRadians, startRadians);
+        if (Math.abs(goalRadians - startRadians) > Math.PI) {
+            return ((Math.PI - Math.abs(startRadians)) + (Math.PI - Math.abs(goalRadians))) 
+                    * Math.sign(startRadians); 
+        }
+        else {
+            return goalRadians - startRadians;
+        }
+    }
 }


### PR DESCRIPTION
got some comments that the grapple rotation felt unnatural as it returns to the player. this causes the grapple to rectify itself smoothly as it returns to the player.

i also identified and corrected the issue of it turning the wrong way sometimes. see the added method in math_util